### PR TITLE
feat(auth): integrate Laravel admin guard for admin auth

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'users',
+        ],
     ],
 
     /*


### PR DESCRIPTION
Replace manual session token checks with Laravel's built-in admin guard   for authentication in the admin dashboard. This simplifies login logic,   improves security by leveraging Laravel's guard system, and ensures proper   logout handling. Update login, logout, and middleware to use the admin guard,   remove redundant session user ID storage, and maintain Sanctum token creation   for API access. Add 'admin' guard configuration to auth.php to support this.